### PR TITLE
fix: correct pageviews extraction

### DIFF
--- a/_includes/pageviews/goatcounter.html
+++ b/_includes/pageviews/goatcounter.html
@@ -10,7 +10,7 @@
       fetch(url)
         .then((response) => response.json())
         .then((data) => {
-          const count = data.count.replace(/\s/g, '');
+          const count = data.count.replace(/\D/g, '');
           pv.innerText = new Intl.NumberFormat().format(count);
         })
         .catch((error) => {


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
**Problem:** `NaN` appears for pageview when over 1K pageview's value is returned by GoatCounter as JSON value contains formatted value like `1,234` that is expected according to [documentation](https://www.goatcounter.com/help/visitor-counter#json-160).

**Solution:** Remove any non-digit symbols from the value before trying to parse it.

## Additional context
Reported by @SoumyaK4, discussed and tested under #2412.
