### PR TITLE
improving giscus repo comment in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,7 +119,7 @@ comments:
     issue_term: # < url | pathname | title | ...>
   # Giscus options › https://giscus.app
   giscus:
-    repo: # <gh-username>/<repo>
+    repo: # <gh-username>/<github pages repo> 
     repo_id:
     category:
     category_id:


### PR DESCRIPTION

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Documentation update

## Description
updated comment next to giscus repo parameter to help others know that it should be the same repo as the github pages repo. otherwise you will get content security policy errors and it won't load properly.

I mistakenly was under the impression that you had to fork/clone the giscus repo into your personal repository, and use that instead, and wanted to hopefully help out someone else in case they had the same thought.

## Additional context
<!-- e.g. Fixes #(issue) -->
