### PR TITLE
docs: update timezone picker reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ theme: jekyll-theme-chirpy
 # otherwise, the layout language will use the default value of 'en'.
 lang: en
 
-# Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
+# Change to your timezone › https://zones.arilyn.cc
 timezone: Asia/Shanghai
 
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md


### PR DESCRIPTION
## Type of change
- [x] Documentation update

## Description
Problem: The link in the `_config.yml` for timezone picker reference is broken as there is no GH page available at https://kevinnovak.github.io/Time-Zone-Picker.

Fix: Use the original one at http://kevalbhatt.github.io/timezone-picker.

The only concern is that [changes were made](https://github.com/kevalbhatt/timezone-picker/commit/da57a84ad59ddeab49d708359083fe3bf3636ed0) in kevinnovak's version but it is only available as plain JSON only which might be inconvenient. There is no information about why the changes were made except for some fixes to misprints.

## Additional context
Fixes #2512
