### PR TITLE
feat: giscus theme in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -124,6 +124,7 @@ comments:
     repo_id:
     category:
     category_id:
+    theme: # optional, default to 'theme map'
     mapping: # optional, default to 'pathname'
     strict: # optional, default to '0'
     input_position: # optional, default to 'bottom'

--- a/_includes/comments/giscus.html
+++ b/_includes/comments/giscus.html
@@ -20,7 +20,7 @@
       'data-strict' : '{{ site.comments.giscus.strict | default: '0' }}',
       'data-reactions-enabled': '{{ site.comments.giscus.reactions_enabled | default: '1' }}',
       'data-emit-metadata': '0',
-      'data-theme': initTheme,
+      'data-theme': '{{ site.comments.giscus.theme | default: initTheme }}',
       'data-input-position': '{{ site.comments.giscus.input_position | default: 'bottom' }}',
       'data-lang': lang,
       'data-loading': 'lazy',


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
Add support for setting the giscus theme in the config file, defaulting to the global theme.

Before
<img width="832" height="398" alt="Screenshot 2025-12-11 at 00 11 29" src="https://github.com/user-attachments/assets/1dede2d4-a3e3-4afe-8640-eb8514e09437" />

After
<img width="832" height="389" alt="Screenshot 2025-12-11 at 00 09 14" src="https://github.com/user-attachments/assets/98a1c88f-2420-45b2-ba2a-7045f196c7e1" />


## Additional context
<!-- e.g. Fixes #(issue) -->
