### PR TITLE
Update robots.txt with content signals

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -3,8 +3,37 @@ permalink: /robots.txt
 # The robots rules
 ---
 
-User-agent: *
+# As a condition of accessing this website, you agree to
+# abide by the following content signals:
 
-Disallow: /norobots/
+# (a)  If a content-signal = yes, you may collect content
+# for the corresponding use.
+# (b)  If a content-signal = no, you may not collect content
+# for the corresponding use.
+# (c)  If the website operator does not include a content
+# signal for a corresponding use, the website operator
+# neither grants nor restricts permission via content signal
+# with respect to the corresponding use.
+
+# The content signals and their meanings are:
+
+# search: building a search index and providing search
+# results (e.g., returning hyperlinks and short excerpts
+# from your website's contents).  Search does not include
+# providing AI-generated search summaries.
+# ai-input: inputting content into one or more AI models
+# (e.g., retrieval augmented generation, grounding, or other
+# real-time taking of content for generative AI search
+# answers).
+# ai-train: training or fine-tuning AI models.
+
+# ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS
+# RESERVATIONS OF RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN
+# UNION DIRECTIVE 2019/790 ON COPYRIGHT AND RELATED RIGHTS
+# IN THE DIGITAL SINGLE MARKET.
+
+User-Agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
 
 Sitemap: {{ '/sitemap.xml' | absolute_url }}


### PR DESCRIPTION

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
Chirpy's robots.txt template has been updated with content signals as defined at https://contentsignals.org.

By default, we are signalling an intent to disallow site usage for training AI models, but continuing to allow use for searches, and as input into AI queries.

Whilst opinionated, this likely maps to user's default preferences, whilst still allowing overrides to be done at the deployment level via `/assets/robots.txt`.

As the `/norobots/` path is unused, this rule has been removed.