### PR TITLE
feat(archive scss): make edge and center gradient color variable for archives tab darkmode

### DIFF
--- a/_sass/pages/_archives.scss
+++ b/_sass/pages/_archives.scss
@@ -72,11 +72,11 @@
         background-color: var(--main-bg, #ffffff);
         background-image: linear-gradient(
           to left,
-          #ffffff,
-          #fbfbfb,
-          #fbfbfb,
-          #fbfbfb,
-          #ffffff
+          var(--timeline-bg-edge),
+          var(--timeline-bg-center),
+          var(--timeline-bg-center),
+          var(--timeline-bg-center),
+          var(--timeline-bg-edge)
         );
       }
 

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -93,7 +93,9 @@
   --categories-hover-bg: rgb(73 75 76);
   --categories-icon-hover-color: white;
 
-  /* Archive */
+  /* Archives */
+  --timeline-bg-edge: rgb(26 26 30);
+  --timeline-bg-center: rgb(39 39 45);
   --timeline-node-bg: rgb(150 152 156);
   --timeline-color: rgb(63 65 68);
   --timeline-year-dot-color: var(--timeline-color);
@@ -136,17 +138,6 @@
         border-bottom-color: var(--card-bg);
       }
     }
-  }
-
-  #archives li:nth-child(odd) {
-    background-image: linear-gradient(
-      to left,
-      rgb(26 26 30),
-      rgb(39 39 45),
-      rgb(39 39 45),
-      rgb(39 39 45),
-      rgb(26 26 30)
-    );
   }
 
   /* stylelint-disable-next-line selector-id-pattern */

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -90,6 +90,8 @@
   --categories-icon-hover-color: darkslategray;
 
   /* Archive */
+  --timeline-bg-edge: #ffffff;
+  --timeline-bg-center: #fbfbfb;
   --timeline-color: rgb(0 0 0 / 7.5%);
   --timeline-node-bg: #c2c6cc;
   --timeline-year-dot-color: #ffffff;


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
I am trying to make a custom timeline to show experiences. Having the color hard coded make it harder to copy among different scss. 
I could not use the previously defined since I want to add a little description for each Job Role and add Company.