### PR TITLE
fix(scss): interpolate font-family variable in share-mastodon custom property

### DIFF
--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -127,7 +127,7 @@ header {
 
 .share-mastodon {
   /* See: https://github.com/justinribeiro/share-to-mastodon#properties */
-  --wc-stm-font-family: v.$font-family-base;
+  --wc-stm-font-family: #{v.$font-family-base};
   --wc-stm-dialog-background-color: var(--card-bg);
   --wc-stm-form-button-border: 1px solid var(--btn-border-color);
   --wc-stm-form-submit-background-color: var(--sidebar-btn-bg);


### PR DESCRIPTION
## Summary
- fix `scss/dollar-variable-no-missing-interpolation` in `_sass/pages/_post.scss`
- change only one line to interpolate `v.$font-family-base` for custom property value

## Why
- `lint-scss` currently fails on unrelated PRs (e.g. #2584) due to this existing violation

## Validation
- `NPM_CONFIG_CACHE=/Users/ethan/code/code-kube-rca/.tmp/npm-cache npm run lint:scss`
- `NPM_CONFIG_CACHE=/Users/ethan/code/code-kube-rca/.tmp/npm-cache npm run lint:js`

Fixes #2665
