### PR TITLE
refactor: correct typos in comments and identifiers

### DIFF
--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -1,6 +1,6 @@
 <!--
   Date format snippet
-  See: ${JS_ROOT}/utils/locale-dateime.js
+  See: ${JS_ROOT}/modules/components/locale-datetime.js
 -->
 
 {% assign df_strftime = site.data.locales[include.lang].df.post.strftime | default: '%d/%m/%Y' %}

--- a/_includes/language-alias.html
+++ b/_includes/language-alias.html
@@ -1,9 +1,7 @@
 {% comment %}
-
   Convert the alias of the syntax language to the official name
 
   See: <https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers>
-
 {% endcomment %}
 
 {% assign _lang = include.language | default: '' %}
@@ -20,13 +18,13 @@
   {% when 'coffeescript', 'coffee', 'coffee-script' %}
     {{ 'CoffeeScript' }}
   {% when 'cs', 'csharp' %}
-   {{ 'C#' }}
+    {{ 'C#' }}
   {% when 'erl' %}
     {{ 'Erlang' }}
   {% when 'graphql' %}
-   {{ 'GraphQL' }}
+    {{ 'GraphQL' }}
   {% when 'haskell', 'hs' %}
-   {{ 'Haskell' }}
+    {{ 'Haskell' }}
   {% when 'javascript', 'js' %}
     {{ 'JavaScript' }}
   {% when 'make', 'mf', 'gnumake', 'bsdmake' %}
@@ -39,22 +37,22 @@
     {{ 'Objective-C' }}
   {% when 'perl', 'pl' %}
     {{ 'Perl' }}
-  {% when 'php','php3','php4','php5' %}
+  {% when 'php', 'php3', 'php4', 'php5' %}
     {{ 'PHP' }}
   {% when 'py' %}
     {{ 'Python' }}
   {% when 'rb' %}
     {{ 'Ruby' }}
-  {% when 'rs','no_run','ignore','should_panic' %}
+  {% when 'rs', 'no_run', 'ignore', 'should_panic' %}
     {{ 'Rust' }}
   {% when 'bash', 'zsh', 'ksh', 'sh' %}
     {{ 'Shell' }}
   {% when 'st', 'squeak' %}
     {{ 'Smalltalk' }}
-  {% when 'tex'%}
+  {% when 'tex' %}
     {{ 'TeX' }}
   {% when 'latex' %}
-    {{ 'LaTex' }}
+    {{ 'LaTeX' }}
   {% when 'ts', 'typescript' %}
     {{ 'TypeScript' }}
   {% when 'vb', 'visualbasic' %}

--- a/_includes/media-url.html
+++ b/_includes/media-url.html
@@ -17,7 +17,7 @@
     {%- comment -%} Add media resources subpath prefix {%- endcomment -%}
     {% assign url = include.subpath | default: '' | append: '/' | append: url %}
 
-    {%- comment -%} Prepend CND URL {%- endcomment -%}
+    {%- comment -%} Prepend CDN URL {%- endcomment -%}
     {% if site.cdn %}
       {% assign url = site.cdn | append: '/' | append: url %}
     {% endif %}

--- a/_includes/post-paginator.html
+++ b/_includes/post-paginator.html
@@ -1,4 +1,4 @@
-<!-- The paginator for post list on HomgPage. -->
+<!-- The paginator for post list on HomePage. -->
 
 <nav aria-label="Page Navigation">
   <ul class="pagination align-items-center mt-4 mb-0">

--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -173,7 +173,7 @@
       {% assign _parent = _right | slice: 1, 4 %}
 
       {% if _parent == '</a>' %}
-        <!-- add class to exist <a> tag -->
+        <!-- add class to existing <a> tag -->
         {% assign _size = _img_content | size | minus: 1 %}
         {% capture _class %}
           class="img-link{% unless _lqip %} shimmer{% endunless %}"

--- a/_javascript/modules/components.js
+++ b/_javascript/modules/components.js
@@ -7,4 +7,4 @@ export { initToc } from './components/toc';
 export { loadMermaid } from './components/mermaid';
 export { modeWatcher } from './components/mode-toggle';
 export { back2top } from './components/back-to-top';
-export { loadTooptip } from './components/tooltip-loader';
+export { loadTooltip } from './components/tooltip-loader';

--- a/_javascript/modules/components/search-display.js
+++ b/_javascript/modules/components/search-display.js
@@ -1,5 +1,5 @@
 /**
- * This script make #search-result-wrapper switch to unload or shown automatically.
+ * This script makes #search-result-wrapper switch to unload or shown automatically.
  */
 
 const btnSbTrigger = document.getElementById('sidebar-trigger');

--- a/_javascript/modules/components/tooltip-loader.js
+++ b/_javascript/modules/components/tooltip-loader.js
@@ -1,6 +1,6 @@
 import Tooltip from 'bootstrap/js/src/tooltip';
 
-export function loadTooptip() {
+export function loadTooltip() {
   const tooltipTriggerList = document.querySelectorAll(
     '[data-bs-toggle="tooltip"]'
   );

--- a/_javascript/modules/layouts/basic.js
+++ b/_javascript/modules/layouts/basic.js
@@ -1,7 +1,7 @@
-import { back2top, loadTooptip, modeWatcher } from '../components';
+import { back2top, loadTooltip, modeWatcher } from '../components';
 
 export function basic() {
   modeWatcher();
   back2top();
-  loadTooptip();
+  loadTooltip();
 }

--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -78,7 +78,7 @@ code {
   }
 
   a > &.highlighter-rouge {
-    padding-bottom: 0; /* show link's underlinke */
+    padding-bottom: 0; /* show link's underline */
     color: inherit;
   }
 
@@ -137,7 +137,8 @@ div[class^='language-'] {
         height: v.$code-dot-size;
         border-radius: 50%;
         background-color: var(--code-header-muted-color);
-        box-shadow: (v.$code-dot-size + v.$code-dot-gap) 0 0
+        box-shadow:
+          (v.$code-dot-size + v.$code-dot-gap) 0 0
             var(--code-header-muted-color),
           (v.$code-dot-size + v.$code-dot-gap) * 2 0 0
             var(--code-header-muted-color);

--- a/_sass/pages/_archives.scss
+++ b/_sass/pages/_archives.scss
@@ -112,7 +112,7 @@
   }
 
   a {
-    /* post title in Archvies */
+    /* post title in Archives */
     margin-left: 2.5rem;
     position: relative;
     top: 0.1rem;


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)
- [x] Documentation update

## Description

- Rename `loadTooptip` to `loadTooltip` in tooltip-loader.js, components.js, and basic.js
- Fix grammar: "This script make" → "This script makes" in search-display.js
- Fix "HomgPage" → "HomePage" in post-paginator.html
- Fix "CND URL" → "CDN URL" in media-url.html
- Fix "locale-dateime.js" → "locale-datetime.js" in datetime.html
- Fix "LaTex" → "LaTeX" in language-alias.html
- Fix "exist <a> tag" → "existing <a> tag" in refactor-content.html
- Fix "Archvies" → "Archives" in _archives.scss
- Fix "underlinke" → "underline" in _syntax.scss

