### PR TITLE
Update the Google Analytics file to match the recommended snippet by Google

### DIFF
--- a/_includes/analytics/google.html
+++ b/_includes/analytics/google.html
@@ -1,13 +1,9 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script defer src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.id }}"></script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.id }}"></script>
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-    gtag('js', new Date());
-    gtag('config', '{{ site.analytics.google.id }}');
-  });
+  gtag('config', '{{ site.analytics.google.id }}');
 </script>


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
I was setting up Google Analytics on my personal blog, which uses the Chirpy theme, and I realized that the content in `_includes/analytics/google.html` seems to be outdated.

The Google Analytics tag setup page recommends the following code, which is present in the pull-request. I have put the template variable in the right place and tested the new setup.

Proof:
> <img width="888" height="329" alt="ga_tag_setup" src="https://github.com/user-attachments/assets/066f3905-3180-4ea3-bf19-833452c83ad1" />


## Additional context
I have read the Contributing Guideline. However, this is my first real contribution to an open source project, so I may have missed something. Tell me if it’s necessary that I create a feature request issue.
