### PR TITLE
feat(ui): lined paper styling for description lists `<dl>`

### DIFF
--- a/_sass/abstracts/_mixins.scss
+++ b/_sass/abstracts/_mixins.scss
@@ -1,3 +1,5 @@
+@use 'variables' as v;
+
 @mixin text-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -77,4 +79,9 @@
 
 @mixin max-w-100 {
   max-width: 100%;
+}
+
+@mixin dl-holes($hole-fill-default, $hole-border-default) {
+  // paper color + hole svg + hole position + add multiple holes vertically
+  background: var(--desc-list-bg) url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{v.$hole-container-width}" height="#{v.$hole-container-height}" viewBox="0 0 #{v.$hole-container-width} #{v.$hole-container-height}"><circle fill="var(--main-bg, #{$hole-fill-default})" stroke="var(--desc-list-border-color, #{$hole-border-default}" stroke-width="#{v.$hole-border-width}" cx="#{v.$hole-cx}" cy="#{v.$hole-cy}" r="#{v.$hole-radius}"/></svg>') 0 0 repeat-y;
 }

--- a/_sass/abstracts/_mixins.scss
+++ b/_sass/abstracts/_mixins.scss
@@ -83,5 +83,5 @@
 
 @mixin dl-holes($hole-fill-default, $hole-border-default) {
   // paper color + hole svg + hole position + add multiple holes vertically
-  background: var(--desc-list-bg) url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{v.$hole-container-width}" height="#{v.$hole-container-height}" viewBox="0 0 #{v.$hole-container-width} #{v.$hole-container-height}"><circle fill="var(--main-bg, #{$hole-fill-default})" stroke="var(--desc-list-border-color, #{$hole-border-default}" stroke-width="#{v.$hole-border-width}" cx="#{v.$hole-cx}" cy="#{v.$hole-cy}" r="#{v.$hole-radius}"/></svg>') 0 0 repeat-y;
+  background: var(--desc-list-bg) url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{v.$margin-width}" height="#{v.$desc-list-line-height}" viewBox="0 0 #{v.$margin-width} #{v.$desc-list-line-height}"><circle fill="var(--main-bg, #{$hole-fill-default})" stroke="var(--desc-list-border-color, #{$hole-border-default}" stroke-width="#{v.$hole-border-width}" cx="#{calc(v.$margin-width / 2)}" cy="#{calc(v.$desc-list-line-height / 2)}" r="#{v.$hole-radius}"/></svg>') 0 0 repeat-y;
 }

--- a/_sass/abstracts/_variables.scss
+++ b/_sass/abstracts/_variables.scss
@@ -28,3 +28,17 @@ $code-icon-width: 1.75rem !default;
 
 $font-family-base: 'Source Sans Pro', 'Microsoft Yahei', sans-serif !default;
 $font-family-heading: Lato, 'Microsoft Yahei', sans-serif !default;
+
+/* notebook paper style for description lists (i.e. `dl`) */
+
+$dt-left-padding: 4rem !default;
+$dd-left-padding: calc($dt-left-padding + 1.75rem) !default;
+$vertical-line-padding: calc($dt-left-padding - 1.25rem) !default;
+$dl-right-padding: 2rem !default;
+$dl-line-spacing: 29px !default;
+$hole-container-width: $vertical-line-padding !default;
+$hole-container-height: $dl-line-spacing !default;
+$hole-border-width: 1px !default;
+$hole-radius: 5px !default;
+$hole-cx: calc($hole-container-width / 2) !default;
+$hole-cy: calc($hole-container-height / 2) !default;

--- a/_sass/abstracts/_variables.scss
+++ b/_sass/abstracts/_variables.scss
@@ -31,14 +31,9 @@ $font-family-heading: Lato, 'Microsoft Yahei', sans-serif !default;
 
 /* notebook paper style for description lists (i.e. `dl`) */
 
-$dt-left-padding: 4rem !default;
-$dd-left-padding: calc($dt-left-padding + 1.75rem) !default;
-$vertical-line-padding: calc($dt-left-padding - 1.25rem) !default;
-$dl-right-padding: 2rem !default;
-$dl-line-spacing: 29px !default;
-$hole-container-width: $vertical-line-padding !default;
-$hole-container-height: $dl-line-spacing !default;
 $hole-border-width: 1px !default;
 $hole-radius: 5px !default;
-$hole-cx: calc($hole-container-width / 2) !default;
-$hole-cy: calc($hole-container-height / 2) !default;
+$margin-width: 3rem !default;
+$desc-list-padding: calc(($margin-width / 2) - $hole-radius) !default;
+$desc-list-text-indent: calc($desc-list-padding + $margin-width) !default;
+$desc-list-line-height: 29px !default;

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -4,7 +4,6 @@
 @use '../abstracts/placeholders';
 @use '../themes/light';
 @use '../themes/dark';
-@use 'sass:map';
 
 :root {
   font-size: 16px;

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -4,6 +4,32 @@
 @use '../abstracts/placeholders';
 @use '../themes/light';
 @use '../themes/dark';
+@use 'sass:map';
+
+// Notebook paper style for description lists (i.e. `dl`)
+$dt-left-padding: 4rem;
+$dd-left-padding: calc($dt-left-padding + 1.75rem);
+$vertical-line-padding: calc($dt-left-padding - 1.25rem);
+$dl-right-padding: 2rem;
+$dl-line-spacing: 29px;
+
+// Holes in paper effect for description lists (i.e. `dl`)
+$hole-container-width: $vertical-line-padding;
+$hole-container-height: $dl-line-spacing;
+$hole-border-width: 1px;
+$hole-radius: 5px;
+$hole-cx: calc($hole-container-width / 2);
+$hole-cy: calc($hole-container-height / 2);
+
+// Manually set circle fill="var(--main-bg)" depending on theme since CSS variables don't work in SVG
+$hole-dark: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{$hole-container-width}" height="#{$hole-container-height}" viewBox="0 0 #{$hole-container-width} #{$hole-container-height}"><circle fill="rgb(27, 27, 30)" stroke="rgba(45, 45, 45, 0.5)" stroke-width="#{$hole-border-width}" cx="#{$hole-cx}" cy="#{$hole-cy}" r="#{$hole-radius}"/></svg>';
+$hole-light: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{$hole-container-width}" height="#{$hole-container-height}" viewBox="0 0 #{$hole-container-width} #{$hole-container-height}"><circle fill="white" stroke="rgb(235, 235, 235)" stroke-width="#{$hole-border-width}" cx="#{$hole-cx}" cy="#{$hole-cy}" r="#{$hole-radius}"/></svg>';
+
+// Theme: paper color + hole svg + hole position + add multiple holes vertically
+$hole-themes: (
+  dark: var(--desc-list-background) url("#{$hole-dark}") 0 0 repeat-y,
+  light: var(--desc-list-background) url("#{$hole-light}") 0 0 repeat-y
+);
 
 :root {
   font-size: 16px;
@@ -208,8 +234,59 @@ main {
     }
   } /* ul */
 
+  dl > dt {
+    padding-left: $dt-left-padding;
+  }
+
   dl > dd {
-    margin-left: 1rem;
+    padding-left: $dd-left-padding;
+  }
+
+  dl > dt, dd {
+    padding-right: $dl-right-padding;
+  }
+
+  dl {
+    position: relative;
+    border: 1px solid var(--desc-list-border);
+    box-shadow: 0 0 5px var(--desc-list-border);
+    border-radius: v.$radius-sm;
+    line-height: $dl-line-spacing;
+    background: map.get($hole-themes, light);
+
+    @each $theme, $bg in $hole-themes {
+      html[data-mode='#{$theme}'] & {
+        background: $bg;
+      }
+
+      html:not([data-mode]) & {
+        @media (prefers-color-scheme: #{$theme}) {
+          background: $bg;
+        }
+      }
+    }
+
+    & > :not(:first-child) {
+      background-size: 100% $dl-line-spacing;
+      background-image: linear-gradient(
+        var(--desc-list-horizontal-line-color) 1px,
+        transparent 0
+      );
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: $vertical-line-padding;
+      width: 1px;
+      background-color: var(--desc-list-vertical-line-color);
+    }
+  }
+
+  dd {
+    margin-bottom: 0;
   }
 
   ::marker {

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -6,31 +6,6 @@
 @use '../themes/dark';
 @use 'sass:map';
 
-// Notebook paper style for description lists (i.e. `dl`)
-$dt-left-padding: 4rem;
-$dd-left-padding: calc($dt-left-padding + 1.75rem);
-$vertical-line-padding: calc($dt-left-padding - 1.25rem);
-$dl-right-padding: 2rem;
-$dl-line-spacing: 29px;
-
-// Holes in paper effect for description lists (i.e. `dl`)
-$hole-container-width: $vertical-line-padding;
-$hole-container-height: $dl-line-spacing;
-$hole-border-width: 1px;
-$hole-radius: 5px;
-$hole-cx: calc($hole-container-width / 2);
-$hole-cy: calc($hole-container-height / 2);
-
-// Manually set circle fill="var(--main-bg)" depending on theme since CSS variables don't work in SVG
-$hole-dark: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{$hole-container-width}" height="#{$hole-container-height}" viewBox="0 0 #{$hole-container-width} #{$hole-container-height}"><circle fill="rgb(27, 27, 30)" stroke="rgba(45, 45, 45, 0.5)" stroke-width="#{$hole-border-width}" cx="#{$hole-cx}" cy="#{$hole-cy}" r="#{$hole-radius}"/></svg>';
-$hole-light: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="#{$hole-container-width}" height="#{$hole-container-height}" viewBox="0 0 #{$hole-container-width} #{$hole-container-height}"><circle fill="white" stroke="rgb(235, 235, 235)" stroke-width="#{$hole-border-width}" cx="#{$hole-cx}" cy="#{$hole-cy}" r="#{$hole-radius}"/></svg>';
-
-// Theme: paper color + hole svg + hole position + add multiple holes vertically
-$hole-themes: (
-  dark: var(--desc-list-background) url("#{$hole-dark}") 0 0 repeat-y,
-  light: var(--desc-list-background) url("#{$hole-light}") 0 0 repeat-y
-);
-
 :root {
   font-size: 16px;
 }
@@ -235,39 +210,26 @@ main {
   } /* ul */
 
   dl > dt {
-    padding-left: $dt-left-padding;
+    padding-left: v.$dt-left-padding;
   }
 
   dl > dd {
-    padding-left: $dd-left-padding;
+    padding-left: v.$dd-left-padding;
   }
 
   dl > dt, dd {
-    padding-right: $dl-right-padding;
+    padding-right: v.$dl-right-padding;
   }
 
   dl {
     position: relative;
-    border: 1px solid var(--desc-list-border);
-    box-shadow: 0 0 5px var(--desc-list-border);
+    border: 1px solid var(--desc-list-border-color);
+    box-shadow: 0 0 5px var(--desc-list-border-color);
     border-radius: v.$radius-sm;
-    line-height: $dl-line-spacing;
-    background: map.get($hole-themes, light);
-
-    @each $theme, $bg in $hole-themes {
-      html[data-mode='#{$theme}'] & {
-        background: $bg;
-      }
-
-      html:not([data-mode]) & {
-        @media (prefers-color-scheme: #{$theme}) {
-          background: $bg;
-        }
-      }
-    }
+    line-height: v.$dl-line-spacing;
 
     & > :not(:first-child) {
-      background-size: 100% $dl-line-spacing;
+      background-size: 100% v.$dl-line-spacing;
       background-image: linear-gradient(
         var(--desc-list-horizontal-line-color) 1px,
         transparent 0
@@ -279,7 +241,7 @@ main {
       position: absolute;
       top: 0;
       bottom: 0;
-      left: $vertical-line-padding;
+      left: v.$vertical-line-padding;
       width: 1px;
       background-color: var(--desc-list-vertical-line-color);
     }

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -209,15 +209,15 @@ main {
   } /* ul */
 
   dl > dt {
-    padding-left: v.$dt-left-padding;
+    padding-left: v.$desc-list-text-indent;
   }
 
   dl > dd {
-    padding-left: v.$dd-left-padding;
+    padding-left: calc(v.$desc-list-text-indent + (v.$desc-list-padding * 1.5));
   }
 
   dl > dt, dd {
-    padding-right: v.$dl-right-padding;
+    padding-right: v.$desc-list-padding;
   }
 
   dl {
@@ -225,12 +225,12 @@ main {
     border: 1px solid var(--desc-list-border-color);
     box-shadow: 0 0 5px var(--desc-list-border-color);
     border-radius: v.$radius-sm;
-    line-height: v.$dl-line-spacing;
+    line-height: v.$desc-list-line-height;
 
     & > :not(:first-child) {
-      background-size: 100% v.$dl-line-spacing;
+      background-size: 100% v.$desc-list-line-height;
       background-image: linear-gradient(
-        var(--desc-list-horizontal-line-color) 1px,
+        var(--desc-list-line-color) 1px,
         transparent 0
       );
     }
@@ -240,9 +240,9 @@ main {
       position: absolute;
       top: 0;
       bottom: 0;
-      left: v.$vertical-line-padding;
+      left: v.$margin-width;
       width: 1px;
-      background-color: var(--desc-list-vertical-line-color);
+      background-color: var(--desc-list-margin-color);
     }
   }
 

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -115,7 +115,7 @@
   
   /* Description List (i.e. <dl>) */
   --desc-list-bg: #151515;
-  --desc-list-border-color: rgba(45, 45, 45, 0.5);
+  --desc-list-border-color: rgb(45 45 45 / 50%);
   --desc-list-horizontal-line-color: #2d2d2d;
   --desc-list-vertical-line-color: var(--desc-list-horizontal-line-color);
 
@@ -311,6 +311,6 @@
 
   /* Description List (i.e. <dl>) */
   .content dl {
-    @include mx.dl-holes(rgb(27, 27, 30), rgba(45, 45, 45, 0.5));
+    @include mx.dl-holes(rgb(27 27 30), rgb(45 45 45 / 50%));
   }
 }

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -110,6 +110,12 @@
   --code-header-icon-color: #565656;
   --clipboard-checked-color: #2bcc2b;
   --filepath-text-color: #cacaca;
+  
+  /* Description List (i.e. <dl>) */
+  --desc-list-background: #151515;
+  --desc-list-border: rgba(45, 45, 45, 0.5);
+  --desc-list-horizontal-line-color: #2d2d2d;
+  --desc-list-vertical-line-color: var(--desc-list-horizontal-line-color);
 
   .light {
     display: none;

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -118,6 +118,10 @@
   --desc-list-border-color: rgb(45 45 45 / 50%);
   --desc-list-horizontal-line-color: #2d2d2d;
   --desc-list-vertical-line-color: var(--desc-list-horizontal-line-color);
+  
+  .content dl {
+    @include mx.dl-holes(rgb(27 27 30), rgb(45 45 45 / 50%));
+  }
 
   .light {
     display: none;
@@ -307,10 +311,5 @@
 
   .highlight .ss {
     color: #90a959;
-  }
-
-  /* Description List (i.e. <dl>) */
-  .content dl {
-    @include mx.dl-holes(rgb(27 27 30), rgb(45 45 45 / 50%));
   }
 }

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -116,8 +116,8 @@
   /* Description List (i.e. <dl>) */
   --desc-list-bg: #151515;
   --desc-list-border-color: rgb(45 45 45 / 50%);
-  --desc-list-horizontal-line-color: #2d2d2d;
-  --desc-list-vertical-line-color: var(--desc-list-horizontal-line-color);
+  --desc-list-line-color: #2d2d2d;
+  --desc-list-margin-color: var(--desc-list-line-color);
   
   .content dl {
     @include mx.dl-holes(rgb(27 27 30), rgb(45 45 45 / 50%));

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/mixins' as mx;
+
 @mixin styles {
   color-scheme: dark;
 
@@ -112,8 +114,8 @@
   --filepath-text-color: #cacaca;
   
   /* Description List (i.e. <dl>) */
-  --desc-list-background: #151515;
-  --desc-list-border: rgba(45, 45, 45, 0.5);
+  --desc-list-bg: #151515;
+  --desc-list-border-color: rgba(45, 45, 45, 0.5);
   --desc-list-horizontal-line-color: #2d2d2d;
   --desc-list-vertical-line-color: var(--desc-list-horizontal-line-color);
 
@@ -305,5 +307,10 @@
 
   .highlight .ss {
     color: #90a959;
+  }
+
+  /* Description List (i.e. <dl>) */
+  .content dl {
+    @include mx.dl-holes(rgb(27, 27, 30), rgba(45, 45, 45, 0.5));
   }
 }

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -111,8 +111,8 @@
   /* Description List (i.e. <dl>) */
   --desc-list-bg: #ffffff;
   --desc-list-border-color: var(--main-border-color);
-  --desc-list-horizontal-line-color: #00b0d7;
-  --desc-list-vertical-line-color: #db4034;
+  --desc-list-line-color: #00b0d7;
+  --desc-list-margin-color: #db4034;
   
   .content dl {
     @include mx.dl-holes(white, rgb(235 235 235)); // rgb(243 243 243));

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -113,6 +113,10 @@
   --desc-list-border-color: var(--main-border-color);
   --desc-list-horizontal-line-color: #00b0d7;
   --desc-list-vertical-line-color: #db4034;
+  
+  .content dl {
+    @include mx.dl-holes(white, rgb(235 235 235)); // rgb(243 243 243));
+  }
 
   [class^='prompt-'] {
     --link-underline-color: rgb(219 216 216);
@@ -313,10 +317,5 @@
   .highlight .gs {
     color: #24292f;
     font-weight: bold;
-  }
-
-  /* Description List (i.e. <dl>) */
-  .content dl {
-    @include mx.dl-holes(white, rgb(235, 235, 235)); // rgb(243, 243, 243));
   }
 }

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/mixins' as mx;
+
 @mixin styles {
   /* Framework color */
   --main-bg: white;
@@ -107,8 +109,8 @@
   --clipboard-checked-color: #43c743;
   
   /* Description List (i.e. <dl>) */
-  --desc-list-background: #ffffff;
-  --desc-list-border: var(--main-border-color);
+  --desc-list-bg: #ffffff;
+  --desc-list-border-color: var(--main-border-color);
   --desc-list-horizontal-line-color: #00b0d7;
   --desc-list-vertical-line-color: #db4034;
 
@@ -311,5 +313,10 @@
   .highlight .gs {
     color: #24292f;
     font-weight: bold;
+  }
+
+  /* Description List (i.e. <dl>) */
+  .content dl {
+    @include mx.dl-holes(white, rgb(235, 235, 235)); // rgb(243, 243, 243));
   }
 }

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -105,6 +105,12 @@
   --code-header-muted-color: #e5e5e5;
   --code-header-icon-color: #c9c8c8;
   --clipboard-checked-color: #43c743;
+  
+  /* Description List (i.e. <dl>) */
+  --desc-list-background: #ffffff;
+  --desc-list-border: var(--main-border-color);
+  --desc-list-horizontal-line-color: #00b0d7;
+  --desc-list-vertical-line-color: #db4034;
 
   [class^='prompt-'] {
     --link-underline-color: rgb(219 216 216);


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
This change is purely aesthetic; I thought it'd be cute and fun to style [description lists](https://chirpy.cotes.page/posts/text-and-typography/#description-list) as lined paper. [Here's a live demo](https://blog.lynkos.dev/posts/custom-storage/#background).

All I did was make changes to certain SCSS files. The colors match the color scheme, though the light mode version looks more "paper-like". The lines are achieved by setting `background-image` to `linear-gradient`, while the holes are inline SVGs.

No [additional] dependencies required.

## Additional context
Light mode
<img alt="Screenshot of description list in light mode" src="https://github.com/user-attachments/assets/6ccf8b85-f75a-4b15-88fd-9997b053e145" />

Dark mode
<img alt="Screenshot of description list in dark mode" src="https://github.com/user-attachments/assets/e4739cc5-326d-4a0d-ae84-2b9527d5ba46" />