### PR TITLE
feat(ui): add `important` type prompt

### DIFF
--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -83,6 +83,9 @@ Moon
 
 > An example showing the `danger` type prompt.
 {: .prompt-danger }
+
+> An example showing the `important` type prompt.
+{: .prompt-important }
 <!-- markdownlint-restore -->
 
 ## Tables

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -85,6 +85,7 @@ blockquote {
   @include mx.prompt('info', '\f06a', $rotate: 180);
   @include mx.prompt('warning', '\f06a');
   @include mx.prompt('danger', '\f071');
+  @include mx.prompt('important', '\f005');
 }
 
 kbd {

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -81,6 +81,8 @@
   --prompt-warning-icon-color: rgb(255 165 0 / 80%);
   --prompt-danger-bg: rgb(86 28 8 / 80%);
   --prompt-danger-icon-color: #cd0202;
+  --prompt-important-bg: rgb(57 9 94 / 80%);
+  --prompt-important-icon-color: #a371f7;
 
   /* Tags */
   --tag-border: rgb(59 79 88);

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -77,7 +77,7 @@
   --prompt-warning-icon-color: #ef9c03;
   --prompt-danger-bg: rgb(248 215 218 / 56%);
   --prompt-danger-icon-color: #df3c30;
-  --prompt-important-bg: #e4d6ff;
+  --prompt-important-bg: rgb(228 214 255 / 60%);
   --prompt-important-icon-color: #8250df;
   
   /* Tags */

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -79,7 +79,7 @@
   --prompt-danger-icon-color: #df3c30;
   --prompt-important-bg: rgb(228 214 255 / 60%);
   --prompt-important-icon-color: #8250df;
-  
+
   /* Tags */
   --tag-border: #dee2e6;
   --tag-shadow: var(--btn-border-color);

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -77,7 +77,9 @@
   --prompt-warning-icon-color: #ef9c03;
   --prompt-danger-bg: rgb(248 215 218 / 56%);
   --prompt-danger-icon-color: #df3c30;
-
+  --prompt-important-bg: #e4d6ff;
+  --prompt-important-icon-color: #8250df;
+  
   /* Tags */
   --tag-border: #dee2e6;
   --tag-shadow: var(--btn-border-color);


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
I was inspired to add an `important` type prompt since [GitHub has one](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), e.g.:

> [!IMPORTANT]
> GitHub's `important` type prompt

## Additional context
Dark mode
<img alt="Screenshot of prompts in dark mode" src="https://github.com/user-attachments/assets/aa6db02a-5482-4cd7-98a7-5682795c0b6f" />

Light mode
<img alt="Screenshot of prompts in light mode" src="https://github.com/user-attachments/assets/82397938-0554-461f-9739-045dd6fe91d1" />
